### PR TITLE
Update parse-uboot-dump.py

### DIFF
--- a/parse-uboot-dump.py
+++ b/parse-uboot-dump.py
@@ -10,9 +10,10 @@ o = open(outfile,"wb")
 
 for line in i.readlines():
     line = line.strip()
+    line = ''.join(char for char in line if ord(char) < 128 and ord(char) != 0)
     if re.match(r'^[0-9a-f]{8}:',line):
         line = line.split(":")
-        if len(line) == 2:
+        if len(line) > 1:
             line = line[1]
             line = line.replace(" ","")[:32]
             data = bytes.fromhex(line)


### PR DESCRIPTION
- Added sanitization for weird chars (mostly null) that randomly came across my serial output.
- Changed len requirements to anything more than 1. My output consistently had hex 3a, which was rendered in the md output as `:`, which would then skip the entire line because len would be more than 2. Output was always smaller than I would expect and caused binwalk to eat dirt.
![image](https://github.com/nmatt0/firmwaretools/assets/54251069/12798298-bb7a-47fd-a627-c1a259dc77c4)
